### PR TITLE
最新の環境で動くよう修正

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,10 @@
+[build]
+target="aarch64-unknown-none"
+
+[objcopy]
+target="aarch64-unknown-none"
+
+
 [target.aarch64-unknown-none]
 rustflags = [
   "-C", "link-arg=-Tlink.ld",

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,6 @@ CARGO_OUTPUT = target/aarch64-unknown-none/release/kernel8
 
 OBJCOPY_ARGS = --strip-all -O binary
 
-CONTAINER_UTILS   = andrerichter/raspi3-utils
-
-DOCKER_CMD        = docker run -it --rm
-DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
-
 .PHONY: all clippy clean objdump nm
 
 all: clean kernel8.img
@@ -44,7 +39,7 @@ kernel8.img: $(CARGO_OUTPUT)
 	cargo objcopy --release -- $(OBJCOPY_ARGS) kernel8.img
 
 clippy:
-	cargo xclippy
+	cargo clippy
 
 clean:
 	cargo clean
@@ -53,7 +48,7 @@ objdump:
 	cargo objdump -- --disassemble --print-imm-hex
 
 llvm:
-	cargo xrustc --release -- --emit=llvm-ir
+	cargo rustc --release -- --emit=llvm-ir
 # => target/aarch64-unknown-none/release/deps/*.ll
 
 nm:
@@ -71,3 +66,5 @@ dump: $(SOURCES)
 
 expand:
 	cargo expand
+# cargo-expand is required: cargo install cargo-expand
+

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 
 SOURCES = $(wildcard **/*.rs) $(wildcard **/*.S) link.ld
 
-CARGO_OUTPUT = target/$(TARGET)/release/kernel8
+CARGO_OUTPUT = target/aarch64-unknown-none/release/kernel8
 
 OBJCOPY_ARGS = --strip-all -O binary
 
@@ -33,9 +33,7 @@ CONTAINER_UTILS   = andrerichter/raspi3-utils
 DOCKER_CMD        = docker run -it --rm
 DOCKER_ARG_CURDIR = -v $(shell pwd):/work -w /work
 
-DOCKER_EXEC_QEMU     = qemu-system-aarch64 -M raspi3 -kernel kernel8.img
-
-.PHONY: all qemu clippy clean objdump nm
+.PHONY: all clippy clean objdump nm
 
 all: clean kernel8.img
 
@@ -44,10 +42,6 @@ $(CARGO_OUTPUT): $(SOURCES)
 
 kernel8.img: $(CARGO_OUTPUT)
 	cargo objcopy --release -- $(OBJCOPY_ARGS) kernel8.img
-
-qemu: all
-	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(CONTAINER_UTILS) \
-	$(DOCKER_EXEC_QEMU) -serial stdio
 
 clippy:
 	cargo xclippy
@@ -66,17 +60,14 @@ nm:
 	cargo nm
 
 gdb: clean $(SOURCES)
-	 cargo xrustc --target=$(TARGET) --release -- -C debuginfo=2
-	 cp target/aarch64-unknown-none/release/kernel8 kernel8_debug
+	 cargo rustc --release -- -C debuginfo=2
+	 cp $(CARGO_OUTPUT) kernel8_debug
 
 gdb-opt0: clean $(SOURCES)
 	$(call gen_gdb,-C debuginfo=2 -C opt-level=0)
 
-dump: clean $(SOURCES)
-	# cargo xrustc --target=$(TARGET) --release -- -C debuginfo=2 -C opt-level=0
-	cargo xrustc --target=$(TARGET) --release -- -C debuginfo=2
-	cp target/aarch64-unknown-none/release/kernel8 kernel8_debug
-	cargo objdump --target $(TARGET) -- -disassemble -print-imm-hex kernel8_debug > dump.s
+dump: $(SOURCES)
+	cargo objdump --release -- --disassemble --print-imm-hex > dump.s
 
 expand:
 	cargo expand

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(CARGO_OUTPUT): $(SOURCES)
 	cargo build --release
 
 kernel8.img: $(CARGO_OUTPUT)
-	cargo objcopy -- $(OBJCOPY_ARGS) kernel8.img
+	cargo objcopy --release -- $(OBJCOPY_ARGS) kernel8.img
 
 qemu: all
 	$(DOCKER_CMD) $(DOCKER_ARG_CURDIR) $(CONTAINER_UTILS) \


### PR DESCRIPTION
最新の`cargo`/`cargo-binutils`で動作するよう修正。

- `cargo-binutils` 0.3.3 で動作するよう`Makefile`を修正
- ほぼ`cargo xxx` でビルド等が可能なため、`Makefile`を簡略化
- 書籍中で言及されていない内容の削除
- コメント等追加

Close #1 